### PR TITLE
feat: runtime env var injection via entrypoint script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,15 +21,6 @@ jobs:
     needs: resolve-version
     if: needs.resolve-version.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - environment: testnet
-            chain_id: vna-testnet-1
-            chain_name: VeranaTestnet1
-          - environment: devnet
-            chain_id: vna-devnet-1
-            chain_name: VeranaDevnet1
 
     env:
       RELEASE_TYPE: ${{ needs.resolve-version.outputs.release-type }}
@@ -72,22 +63,13 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}${{ env.SUFFIX }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}${{ env.SUFFIX }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}.${{ env.RELEASE_PATCH_SHORT }}${{ env.SUFFIX }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ matrix.environment }}
-          build-args: |
-            NEXT_PUBLIC_BASE_URL=https://vis.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_GITHUB_TOKEN=${{ secrets.TOKEN_GITHUB }}
-            NEXT_PUBLIC_API_ENDPOINT=https://api.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_RPC_ENDPOINT=https://rpc.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_IDX_ENDPOINT=https://idx.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_RESOLVER_ENDPOINT=https://resolver.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_CHAIN_ID=${{ matrix.chain_id }}
-            NEXT_PUBLIC_CHAIN_NAME=${{ matrix.chain_name }}
-          cache-from: type=gha,scope=${{ matrix.environment }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.environment }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}${{ env.SUFFIX }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}${{ env.SUFFIX }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}.${{ env.RELEASE_PATCH_SHORT }}${{ env.SUFFIX }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build & push stable release tags
         if: env.RELEASE_TYPE == 'stable'
@@ -98,21 +80,12 @@ jobs:
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}${{ env.SUFFIX }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}${{ env.SUFFIX }}-${{ matrix.environment }}
-            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}-${{ matrix.environment }}
-          build-args: |
-            NEXT_PUBLIC_BASE_URL=https://vis.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_GITHUB_TOKEN=${{ secrets.TOKEN_GITHUB }}
-            NEXT_PUBLIC_API_ENDPOINT=https://api.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_RPC_ENDPOINT=https://rpc.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_IDX_ENDPOINT=https://idx.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_RESOLVER_ENDPOINT=https://resolver.${{ matrix.environment }}.verana.network
-            NEXT_PUBLIC_CHAIN_ID=${{ matrix.chain_id }}
-            NEXT_PUBLIC_CHAIN_NAME=${{ matrix.chain_name }}
-          cache-from: type=gha,scope=${{ matrix.environment }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.environment }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}${{ env.SUFFIX }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:v${{ env.RELEASE_MAJOR }}.${{ env.RELEASE_MINOR }}${{ env.SUFFIX }}
+            ${{ secrets.DOCKER_HUB_LOGIN }}/${{ env.IMAGE_NAME }}:${{ env.RELEASE_VERSION }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Set up Helm
         uses: azure/setup-helm@v3
@@ -121,11 +94,11 @@ jobs:
         run: |
           CHART_NAME=$(grep '^name:' ./charts/Chart.yaml | awk '{print $2}')
           if [ "$RELEASE_TYPE" = "stable" ]; then
-            TAGS=("${RELEASE_VERSION}-${{ matrix.environment }}")
+            TAGS=("${RELEASE_VERSION}")
           else
             TAGS=(
-              "v${RELEASE_MAJOR}.${RELEASE_MINOR}.${RELEASE_PATCH:0:1}-dev-${{ matrix.environment }}"
-              "${RELEASE_VERSION}-${{ matrix.environment }}"
+              "v${RELEASE_MAJOR}.${RELEASE_MINOR}.${RELEASE_PATCH:0:1}-dev"
+              "${RELEASE_VERSION}"
             )
           fi
           for tag in "${TAGS[@]}"; do

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,27 +12,6 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-ARG NEXT_PUBLIC_BASE_URL=http://localhost:3000
-ARG NEXT_PUBLIC_GITHUB_TOKEN
-ARG NEXT_PUBLIC_API_ENDPOINT=https://api.testnet.verana.network
-ARG NEXT_PUBLIC_RPC_ENDPOINT=https://rpc.testnet.verana.network
-ARG NEXT_PUBLIC_IDX_ENDPOINT=https://idx.testnet.verana.network
-ARG NEXT_PUBLIC_RESOLVER_ENDPOINT=https://resolver.testnet.verana.network
-ARG NEXT_PUBLIC_CHAIN_ID=vna-testnet-1
-ARG NEXT_PUBLIC_CHAIN_NAME=Testnet
-ARG NEXT_PUBLIC_APP_NAME=verana-visualizer
-ARG NEXT_PUBLIC_APP_LOGO=logo.svg
-
-ENV NEXT_PUBLIC_BASE_URL=${NEXT_PUBLIC_BASE_URL}
-ENV NEXT_PUBLIC_GITHUB_TOKEN=${NEXT_PUBLIC_GITHUB_TOKEN}
-ENV NEXT_PUBLIC_API_ENDPOINT=${NEXT_PUBLIC_API_ENDPOINT}
-ENV NEXT_PUBLIC_RPC_ENDPOINT=${NEXT_PUBLIC_RPC_ENDPOINT}
-ENV NEXT_PUBLIC_IDX_ENDPOINT=${NEXT_PUBLIC_IDX_ENDPOINT}
-ENV NEXT_PUBLIC_RESOLVER_ENDPOINT=${NEXT_PUBLIC_RESOLVER_ENDPOINT}
-ENV NEXT_PUBLIC_CHAIN_ID=${NEXT_PUBLIC_CHAIN_ID}
-ENV NEXT_PUBLIC_CHAIN_NAME=${NEXT_PUBLIC_CHAIN_NAME}
-ENV NEXT_PUBLIC_APP_NAME=${NEXT_PUBLIC_APP_NAME}
-ENV NEXT_PUBLIC_APP_LOGO=${NEXT_PUBLIC_APP_LOGO}
 
 RUN npm run build
 
@@ -52,6 +31,8 @@ RUN chown nextjs:nodejs .next
 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/entrypoint.sh ./entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 USER nextjs
 
@@ -60,4 +41,5 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -65,7 +65,6 @@ affinity: {}
 
 env:
   NODE_ENV: "production"
-  NEXT_PUBLIC_BASE_URL: "https://vis.testnet.verana.network"
   NEXT_PUBLIC_API_ENDPOINT: "https://api.testnet.verana.network"
   NEXT_PUBLIC_RPC_ENDPOINT: "https://rpc.testnet.verana.network"
   NEXT_PUBLIC_IDX_ENDPOINT: "https://idx.testnet.verana.network"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# Runtime environment variables are handled by next-runtime-env
+# No file modification needed - NEXT_PUBLIC_* vars are read at runtime
+# See: https://github.com/expatfile/next-runtime-env
+
+# Validate required environment variables
+REQUIRED_VARS="
+NEXT_PUBLIC_API_ENDPOINT
+NEXT_PUBLIC_RPC_ENDPOINT
+"
+
+echo "Validating environment variables..."
+missing_vars=""
+
+for var in $REQUIRED_VARS; do
+    val=$(eval echo "\$$var")
+    if [ -z "$val" ]; then
+        missing_vars="$missing_vars $var"
+        echo "ERROR: Missing required environment variable: $var"
+    fi
+done
+
+if [ -n "$missing_vars" ]; then
+    echo "FATAL: Required environment variables are missing:$missing_vars"
+    echo "Please configure these variables in your Kubernetes deployment."
+    exit 1
+fi
+
+echo "Environment validation passed"
+echo "Starting Next.js"
+exec "$@"

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,5 @@
 const nextConfig = {
   output: 'standalone',
-  basePath: process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_BASE_URL ? 
-    new URL(process.env.NEXT_PUBLIC_BASE_URL).pathname !== '/' ? 
-    new URL(process.env.NEXT_PUBLIC_BASE_URL).pathname : undefined 
-    : undefined,
-  assetPrefix: process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_BASE_URL || '' : '',
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "3d-force-graph": "^1.79.0",
         "next": "15.5.9",
+        "next-runtime-env": "^3.3.0",
         "react": "^18",
         "react-dom": "^18",
         "react-force-graph-2d": "^1.29.0",
@@ -253,7 +254,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -277,7 +277,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1561,6 +1560,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "15.5.7",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
@@ -1958,6 +1973,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1973,7 +1994,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2174,7 +2194,6 @@
       "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2192,7 +2211,6 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2204,7 +2222,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2254,7 +2271,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -2932,7 +2948,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3413,7 +3428,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3426,6 +3440,17 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/cac": {
@@ -3902,7 +3927,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4537,7 +4561,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4707,7 +4730,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5504,6 +5526,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -6306,7 +6334,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6336,7 +6363,6 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -6832,6 +6858,277 @@
         }
       }
     },
+    "node_modules/next-runtime-env": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/next-runtime-env/-/next-runtime-env-3.3.0.tgz",
+      "integrity": "sha512-JgKVnog9mNbjbjH9csVpMnz2tB2cT5sLF+7O47i6Ze/s/GoiKdV7dHhJHk1gwXpo6h5qPj5PTzryldtSjvrHuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "next": "^14",
+        "react": "^18"
+      },
+      "peerDependencies": {
+        "next": "^14",
+        "react": "^18"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7238,7 +7535,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7308,7 +7604,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7574,7 +7869,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7587,7 +7881,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8300,6 +8593,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -8768,8 +9069,7 @@
       "version": "0.180.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
       "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/three-forcegraph": {
       "version": "1.43.0",
@@ -9078,7 +9378,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9245,7 +9544,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -9329,7 +9627,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "3d-force-graph": "^1.79.0",
     "next": "15.5.9",
+    "next-runtime-env": "^3.3.0",
     "react": "^18",
     "react-dom": "^18",
     "react-force-graph-2d": "^1.29.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { PublicEnvScript } from 'next-runtime-env'
 import './globals.css'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -21,6 +22,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <PublicEnvScript />
+      </head>
       <body className={inter.className}>{children}</body>
     </html>
   )

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,12 +20,15 @@ import {
   ProposalResponse,
   BlockAtHeightResponse
 } from '@/types'
+import { env } from 'next-runtime-env'
 
-const API_ENDPOINT = process.env.NEXT_PUBLIC_API_ENDPOINT || 'https://api.testnet.verana.network'
-const RPC_ENDPOINT = process.env.NEXT_PUBLIC_RPC_ENDPOINT || 'https://rpc.testnet.verana.network'
+const getApiEndpoint = () =>
+  env('NEXT_PUBLIC_API_ENDPOINT') || process.env.NEXT_PUBLIC_API_ENDPOINT || 'https://api.testnet.verana.network'
+const getRpcEndpoint = () =>
+  env('NEXT_PUBLIC_RPC_ENDPOINT') || process.env.NEXT_PUBLIC_RPC_ENDPOINT || 'https://rpc.testnet.verana.network'
 
 export async function fetchTrustRegistry(trId: string): Promise<ApiResponse<{ trust_registry: TrustRegistry }>> {
-  const response = await fetch(`${API_ENDPOINT}/verana/tr/v1/get/${trId}`)
+  const response = await fetch(`${getApiEndpoint()}/verana/tr/v1/get/${trId}`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch trust registry: ${response.statusText}`)
@@ -35,7 +38,7 @@ export async function fetchTrustRegistry(trId: string): Promise<ApiResponse<{ tr
 }
 
 export async function fetchCredentialSchemas(trId: string): Promise<ApiResponse<{ schemas: CredentialSchema[] }>> {
-  const response = await fetch(`${API_ENDPOINT}/verana/tr/v1/schemas/${trId}`)
+  const response = await fetch(`${getApiEndpoint()}/verana/tr/v1/schemas/${trId}`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch credential schemas: ${response.statusText}`)
@@ -45,7 +48,7 @@ export async function fetchCredentialSchemas(trId: string): Promise<ApiResponse<
 }
 
 export async function fetchTrustRegistryList(maxSize: number = 100): Promise<TrustRegistryListResponse> {
-  const response = await fetch(`${API_ENDPOINT}/verana/tr/v1/list?response_max_size=${maxSize}`)
+  const response = await fetch(`${getApiEndpoint()}/verana/tr/v1/list?response_max_size=${maxSize}`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch trust registry list: ${response.statusText}`)
@@ -77,7 +80,7 @@ export function formatSnakeCaseToTitleCase(str: string): string {
 }
 
 export async function fetchAbciInfo(): Promise<AbciInfoResponse> {
-  const response = await fetch(`${RPC_ENDPOINT}/abci_info`)
+  const response = await fetch(`${getRpcEndpoint()}/abci_info`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch ABCI info: ${response.statusText}`)
@@ -87,7 +90,7 @@ export async function fetchAbciInfo(): Promise<AbciInfoResponse> {
 }
 
 export async function fetchLatestBlock(): Promise<BlockResponse> {
-  const response = await fetch(`${RPC_ENDPOINT}/block`)
+  const response = await fetch(`${getRpcEndpoint()}/block`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch latest block: ${response.statusText}`)
@@ -97,7 +100,7 @@ export async function fetchLatestBlock(): Promise<BlockResponse> {
 }
 
 export async function fetchGenesis(): Promise<GenesisResponse> {
-  const response = await fetch(`${RPC_ENDPOINT}/genesis`)
+  const response = await fetch(`${getRpcEndpoint()}/genesis`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch genesis: ${response.statusText}`)
@@ -121,7 +124,7 @@ export function formatTotalSupply(amount: string): string {
 }
 
 export async function fetchDIDList(): Promise<DIDListResponse> {
-  const response = await fetch(`${API_ENDPOINT}/verana/dd/v1/list`)
+  const response = await fetch(`${getApiEndpoint()}/verana/dd/v1/list`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch DID list: ${response.statusText}`)
@@ -131,7 +134,7 @@ export async function fetchDIDList(): Promise<DIDListResponse> {
 }
 
 export async function fetchSupply(): Promise<SupplyResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/bank/v1beta1/supply`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/bank/v1beta1/supply`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch supply: ${response.statusText}`)
@@ -141,7 +144,7 @@ export async function fetchSupply(): Promise<SupplyResponse> {
 }
 
 export async function fetchInflation(): Promise<InflationResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/mint/v1beta1/inflation`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/mint/v1beta1/inflation`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch inflation: ${response.statusText}`)
@@ -151,7 +154,7 @@ export async function fetchInflation(): Promise<InflationResponse> {
 }
 
 export async function fetchMintParams(): Promise<MintParamsResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/mint/v1beta1/params`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/mint/v1beta1/params`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch mint params: ${response.statusText}`)
@@ -161,7 +164,7 @@ export async function fetchMintParams(): Promise<MintParamsResponse> {
 }
 
 export async function fetchStakingPool(): Promise<StakingPoolResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/pool`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/pool`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch staking pool: ${response.statusText}`)
@@ -171,7 +174,7 @@ export async function fetchStakingPool(): Promise<StakingPoolResponse> {
 }
 
 export async function fetchCommunityPool(): Promise<CommunityPoolResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/pool`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/pool`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch community pool: ${response.statusText}`)
@@ -181,7 +184,7 @@ export async function fetchCommunityPool(): Promise<CommunityPoolResponse> {
 }
 
 export async function fetchValidators(): Promise<ValidatorsResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/validators`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/validators`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch validators: ${response.statusText}`)
@@ -191,7 +194,7 @@ export async function fetchValidators(): Promise<ValidatorsResponse> {
 }
 
 export async function fetchProposals(): Promise<ProposalsResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/gov/v1/proposals`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/gov/v1/proposals`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch proposals: ${response.statusText}`)
@@ -201,7 +204,7 @@ export async function fetchProposals(): Promise<ProposalsResponse> {
 }
 
 export async function fetchDenomsMetadata(): Promise<DenomsMetadataResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/bank/v1beta1/denoms_metadata`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/bank/v1beta1/denoms_metadata`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch denoms metadata: ${response.statusText}`)
@@ -211,7 +214,7 @@ export async function fetchDenomsMetadata(): Promise<DenomsMetadataResponse> {
 }
 
 export async function fetchHeader(): Promise<HeaderResponse> {
-  const response = await fetch(`${RPC_ENDPOINT}/header`)
+  const response = await fetch(`${getRpcEndpoint()}/header`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch header: ${response.statusText}`)
@@ -228,7 +231,7 @@ export async function fetchHeader(): Promise<HeaderResponse> {
  * Fetch a single proposal by ID
  */
 export async function fetchProposal(proposalId: string): Promise<ProposalResponse> {
-  const response = await fetch(`${API_ENDPOINT}/cosmos/gov/v1/proposals/${proposalId}`)
+  const response = await fetch(`${getApiEndpoint()}/cosmos/gov/v1/proposals/${proposalId}`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch proposal ${proposalId}: ${response.statusText}`)
@@ -242,7 +245,7 @@ export async function fetchProposal(proposalId: string): Promise<ProposalRespons
  * Used to get execution time for upgrade proposals
  */
 export async function fetchBlockAtHeight(height: string | number): Promise<BlockAtHeightResponse> {
-  const response = await fetch(`${RPC_ENDPOINT}/block?height=${height}`)
+  const response = await fetch(`${getRpcEndpoint()}/block?height=${height}`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch block at height ${height}: ${response.statusText}`)
@@ -255,7 +258,7 @@ export async function fetchBlockAtHeight(height: string | number): Promise<Block
  * Get current chain height from RPC status
  */
 export async function fetchCurrentHeight(): Promise<string> {
-  const response = await fetch(`${RPC_ENDPOINT}/status`)
+  const response = await fetch(`${getRpcEndpoint()}/status`)
   
   if (!response.ok) {
     throw new Error(`Failed to fetch chain status: ${response.statusText}`)

--- a/src/lib/githubApi.ts
+++ b/src/lib/githubApi.ts
@@ -7,18 +7,19 @@ import {
   AggregatedContributor,
   GitHubApiError
 } from '@/types'
+import { env } from 'next-runtime-env'
 
 const GITHUB_API_BASE = 'https://api.github.com'
 
-// Get GitHub token from environment variable
-const GITHUB_TOKEN = process.env.NEXT_PUBLIC_GITHUB_TOKEN
+const getGitHubToken = () =>
+  env('NEXT_PUBLIC_GITHUB_TOKEN') || process.env.NEXT_PUBLIC_GITHUB_TOKEN
 
 // Rate limit warning
 let hasWarnedAboutRateLimit = false
 
 function warnAboutRateLimit() {
   if (!hasWarnedAboutRateLimit) {
-    if (GITHUB_TOKEN) {
+    if (getGitHubToken()) {
       console.log(
         '✅ GitHub API: Using authenticated requests (5,000 requests/hour limit)'
       )
@@ -40,8 +41,8 @@ function getGitHubHeaders(): HeadersInit {
     'Accept': 'application/vnd.github.v3+json',
   }
   
-  if (GITHUB_TOKEN) {
-    headers['Authorization'] = `Bearer ${GITHUB_TOKEN}`
+  if (getGitHubToken()) {
+    headers['Authorization'] = `Bearer ${getGitHubToken()}`
   }
   
   return headers
@@ -51,7 +52,7 @@ function getGitHubHeaders(): HeadersInit {
  * Check if GitHub token is configured
  */
 export function hasGitHubToken(): boolean {
-  return !!GITHUB_TOKEN
+  return !!getGitHubToken()
 }
 
 /**
@@ -79,19 +80,19 @@ export async function fetchOrganizationRepos(org: string): Promise<GitHubReposit
           rateLimitRemaining,
           rateLimitReset,
           resetTime: resetTimeStr,
-          hasToken: !!GITHUB_TOKEN,
+          hasToken: !!getGitHubToken(),
           org
         })
         
         if (rateLimitRemaining === '0') {
           throw new Error(
             `GitHub API rate limit exceeded. Limit resets at ${resetTimeStr}. ` +
-            `${GITHUB_TOKEN ? 'Token is configured but limit still hit.' : 'Add a GitHub token to increase limits from 60 to 5,000 requests/hour.'}`
+            `${getGitHubToken() ? 'Token is configured but limit still hit.' : 'Add a GitHub token to increase limits from 60 to 5,000 requests/hour.'}`
           )
         }
         
         // If not rate limit, might be invalid token or private org
-        if (GITHUB_TOKEN) {
+        if (getGitHubToken()) {
           throw new Error(
             `Access forbidden (403). This could mean:\n` +
             `• Your GitHub token may be invalid or expired\n` +

--- a/src/lib/historicalDataFetcher.ts
+++ b/src/lib/historicalDataFetcher.ts
@@ -4,8 +4,12 @@
  * Uses the Verana network REST API with height parameters to build time-series data.
  */
 
-const API_ENDPOINT = process.env.NEXT_PUBLIC_API_ENDPOINT || 'https://api.testnet.verana.network'
-const RPC_ENDPOINT = process.env.NEXT_PUBLIC_RPC_ENDPOINT || 'https://rpc.testnet.verana.network'
+import { env } from 'next-runtime-env'
+
+const getApiEndpoint = () =>
+  env('NEXT_PUBLIC_API_ENDPOINT') || process.env.NEXT_PUBLIC_API_ENDPOINT || 'https://api.testnet.verana.network'
+const getRpcEndpoint = () =>
+  env('NEXT_PUBLIC_RPC_ENDPOINT') || process.env.NEXT_PUBLIC_RPC_ENDPOINT || 'https://rpc.testnet.verana.network'
 
 interface BlockInfo {
   height: number
@@ -17,7 +21,7 @@ interface BlockInfo {
  */
 export async function getCurrentBlockHeight(): Promise<number> {
   try {
-    const response = await fetch(`${RPC_ENDPOINT}/block`)
+    const response = await fetch(`${getRpcEndpoint()}/block`)
     const data = await response.json()
     return parseInt(data.result?.block?.header?.height || '0')
   } catch (error) {
@@ -31,7 +35,7 @@ export async function getCurrentBlockHeight(): Promise<number> {
  */
 export async function getBlockAtHeight(height: number): Promise<BlockInfo> {
   try {
-    const response = await fetch(`${RPC_ENDPOINT}/block?height=${height}`)
+    const response = await fetch(`${getRpcEndpoint()}/block?height=${height}`)
     const data = await response.json()
     return {
       height: parseInt(data.result?.block?.header?.height || '0'),
@@ -48,7 +52,7 @@ export async function getBlockAtHeight(height: number): Promise<BlockInfo> {
  */
 export async function getSupplyAtHeight(height: number) {
   try {
-    const response = await fetch(`${API_ENDPOINT}/cosmos/bank/v1beta1/supply?height=${height}`)
+    const response = await fetch(`${getApiEndpoint()}/cosmos/bank/v1beta1/supply?height=${height}`)
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
@@ -62,7 +66,7 @@ export async function getSupplyAtHeight(height: number) {
  */
 export async function getStakingPoolAtHeight(height: number) {
   try {
-    const response = await fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/pool?height=${height}`)
+    const response = await fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/pool?height=${height}`)
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
@@ -76,7 +80,7 @@ export async function getStakingPoolAtHeight(height: number) {
  */
 export async function getInflationAtHeight(height: number) {
   try {
-    const response = await fetch(`${API_ENDPOINT}/cosmos/mint/v1beta1/inflation?height=${height}`)
+    const response = await fetch(`${getApiEndpoint()}/cosmos/mint/v1beta1/inflation?height=${height}`)
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
@@ -90,7 +94,7 @@ export async function getInflationAtHeight(height: number) {
  */
 export async function getValidatorsAtHeight(height: number) {
   try {
-    const response = await fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/validators?height=${height}`)
+    const response = await fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/validators?height=${height}`)
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
@@ -276,7 +280,7 @@ export async function fetchHistoricalNetworkActivity(dataPoints: number = 30): P
       const results = await Promise.allSettled(
         batch.map(async (height) => {
           try {
-            const blockResponse = await fetch(`${RPC_ENDPOINT}/block?height=${height}`)
+            const blockResponse = await fetch(`${getRpcEndpoint()}/block?height=${height}`)
             const blockData = await blockResponse.json()
             
             const block = blockData.result?.block
@@ -289,7 +293,7 @@ export async function fetchHistoricalNetworkActivity(dataPoints: number = 30): P
             let blockTime = 5.5 // Default estimate
             if (height > 1) {
               try {
-                const prevBlockResponse = await fetch(`${RPC_ENDPOINT}/block?height=${height - 1}`)
+                const prevBlockResponse = await fetch(`${getRpcEndpoint()}/block?height=${height - 1}`)
                 const prevBlockData = await prevBlockResponse.json()
                 const prevTime = new Date(prevBlockData.result?.block?.header?.time)
                 const currTime = new Date(timestamp)
@@ -341,7 +345,7 @@ interface ValidatorDataPoint {
  */
 export async function fetchCurrentValidatorDistribution(): Promise<ValidatorDataPoint[]> {
   try {
-    const response = await fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/validators`)
+    const response = await fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/validators`)
     if (!response.ok) throw new Error('Failed to fetch validators')
     
     const data = await response.json()
@@ -373,8 +377,8 @@ interface StakingDataPoint {
 export async function fetchCurrentStakingDistribution(): Promise<StakingDataPoint[]> {
   try {
     const [supplyResponse, poolResponse] = await Promise.all([
-      fetch(`${API_ENDPOINT}/cosmos/bank/v1beta1/supply`),
-      fetch(`${API_ENDPOINT}/cosmos/staking/v1beta1/pool`)
+      fetch(`${getApiEndpoint()}/cosmos/bank/v1beta1/supply`),
+      fetch(`${getApiEndpoint()}/cosmos/staking/v1beta1/pool`)
     ])
     
     if (!supplyResponse.ok || !poolResponse.ok) {


### PR DESCRIPTION
Replaces build-time NEXT_PUBLIC_* env var baking with runtime injection using next-runtime-env, so a single Docker image works across all environments (testnet, devnet etc).

This was the last piece blocking us from having truly environment-agnostic images — until now we needed separate builds per env

- Added next-runtime-env with PublicEnvScript in the root layout head, which injects a script tag populating window.__ENV at runtime
- Created entrypoint.sh that validates NEXT_PUBLIC_API_ENDPOINT and NEXT_PUBLIC_RPC_ENDPOINT are set before starting the app
- Simplified the CD workflow: single image build instead of matrix strategy, no environment suffix in tags or chart versions

Tested locally

Follow-up PR in verana-deploy to remove NEXT_PUBLIC_BASE_URL from helm values and drop the betanet

Closes #32