### PR TITLE
feat(lib): add logger module and route console.* through it

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -84,7 +84,7 @@
         "noInvalidUseBeforeDeclaration": "error"
       },
       "suspicious": {
-        "noConsole": "off"
+        "noConsole": "error"
       },
       "complexity": {
         "noBannedTypes": "error"

--- a/src/app/api/ecosystem/metrics/route.ts
+++ b/src/app/api/ecosystem/metrics/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { logger } from '@/lib/logger'
 
 const IDX_ENDPOINT = process.env.IDX_ENDPOINT || 'https://idx.testnet.verana.network'
 
@@ -24,7 +25,7 @@ export async function GET(request: NextRequest) {
     const data = await response.json()
     return NextResponse.json(data)
   } catch (error) {
-    console.error('Error proxying metrics request:', error)
+    logger.error('Error proxying metrics request:', error)
     return NextResponse.json({ error: 'Failed to fetch metrics from indexer' }, { status: 502 })
   }
 }

--- a/src/app/charts/page.tsx
+++ b/src/app/charts/page.tsx
@@ -12,6 +12,7 @@ import {
   fetchHistoricalNetworkActivity,
   fetchHistoricalSupplyData,
 } from '@/lib/historicalDataFetcher'
+import { logger } from '@/lib/logger'
 
 export default function ChartsPage() {
   const [tokenSupplyData, setTokenSupplyData] = useState<any[]>([])
@@ -32,7 +33,7 @@ export default function ChartsPage() {
         setError(null)
         setLoadingProgress(0)
 
-        console.log('Fetching historical data from Verana blockchain...')
+        logger.log('Fetching historical data from Verana blockchain...')
         setChartsLoaded(0)
 
         // Load charts progressively - show each as it loads
@@ -75,7 +76,7 @@ export default function ChartsPage() {
         setLoadingMessage('All charts loaded!')
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load chart data')
-        console.error('Error loading chart data:', err)
+        logger.error('Error loading chart data:', err)
       } finally {
         setIsLoading(false)
       }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import {
   fetchSupply,
   fetchValidators,
 } from '@/lib/api'
+import { logger } from '@/lib/logger'
 import {
   CommunityPoolResponse,
   HeaderResponse,
@@ -85,7 +86,7 @@ export default function Dashboard() {
       setIsConnected(true)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load network data')
-      console.error('Error loading network data:', err)
+      logger.error('Error loading network data:', err)
 
       // Mark as disconnected on error
       setIsConnected(false)
@@ -109,7 +110,7 @@ export default function Dashboard() {
     // Using isRefresh=true to show refresh indicator
     const refreshTimer = setInterval(() => {
       loadNetworkData(true).catch((err) => {
-        console.error('Auto-refresh failed:', err)
+        logger.error('Auto-refresh failed:', err)
         setIsConnected(false)
       })
     }, 30000)

--- a/src/app/developer-activity/page.tsx
+++ b/src/app/developer-activity/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { ContributorsSection, RepositoryCard, SkeletonCard } from '@/components/developer-activity'
 import { LayoutWrapper } from '@/components/layout'
 import { aggregateContributors, fetchOrganizationRepos, fetchRepositoryStats, hasGitHubToken } from '@/lib/githubApi'
+import { logger } from '@/lib/logger'
 import { AggregatedContributor, RepositoryStats } from '@/types'
 
 const ORGANIZATION = 'verana-labs'
@@ -25,7 +26,7 @@ export default function DeveloperActivityPage() {
       setRepoStats([]) // Clear previous data
       setContributors([])
 
-      console.log(`Fetching repositories from ${ORGANIZATION} organization...`)
+      logger.log(`Fetching repositories from ${ORGANIZATION} organization...`)
 
       // Fetch all repositories
       setLoadingMessage('Fetching repositories...')
@@ -36,7 +37,7 @@ export default function DeveloperActivityPage() {
         throw new Error('No repositories found for the organization')
       }
 
-      console.log(`Found ${repos.length} repositories`)
+      logger.log(`Found ${repos.length} repositories`)
       setTotalRepos(repos.length)
       setLoadingProgress(20)
 
@@ -76,14 +77,14 @@ export default function DeveloperActivityPage() {
         setContributors(partialContributors)
       }
 
-      console.log(`Successfully fetched stats for ${validStats.length} repositories`)
+      logger.log(`Successfully fetched stats for ${validStats.length} repositories`)
 
       setLoadingProgress(100)
       setLoadingMessage('Complete!')
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Failed to load developer activity'
       setError(errorMessage)
-      console.error('Error loading developer activity:', err)
+      logger.error('Error loading developer activity:', err)
     } finally {
       setIsLoading(false)
     }
@@ -91,8 +92,8 @@ export default function DeveloperActivityPage() {
 
   useEffect(() => {
     // Log token status for debugging
-    console.log('Token configured:', hasGitHubToken())
-    console.log('Organization to fetch:', ORGANIZATION)
+    logger.log('Token configured:', hasGitHubToken())
+    logger.log('Organization to fetch:', ORGANIZATION)
     loadDeveloperActivity()
   }, [])
 

--- a/src/app/did-directory/page.tsx
+++ b/src/app/did-directory/page.tsx
@@ -6,6 +6,7 @@ import { LayoutWrapper } from '@/components/layout'
 import { ResultsSection, SearchForm } from '@/components/search'
 import { DIDTable } from '@/components/tables'
 import { fetchDIDList } from '@/lib/api'
+import { logger } from '@/lib/logger'
 import { DID } from '@/types'
 
 const didMatchesQuery = (did: DID, query: string) => {
@@ -41,7 +42,7 @@ function DIDDirectoryContent() {
         setError(null)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load DIDs')
-        console.error('Error loading DIDs:', err)
+        logger.error('Error loading DIDs:', err)
       } finally {
         setIsLoading(false)
       }

--- a/src/app/ecosystem/page.tsx
+++ b/src/app/ecosystem/page.tsx
@@ -8,6 +8,7 @@ import EcosystemTrustSummary from '@/components/ecosystem/EcosystemTrustSummary'
 import { LayoutWrapper } from '@/components/layout'
 import { fetchEcosystemMetrics } from '@/lib/api'
 import { fetchHistoricalEcosystemData } from '@/lib/ecosystemDataFetcher'
+import { logger } from '@/lib/logger'
 import { EcosystemMetrics, EcosystemMetricsDataPoint } from '@/types'
 
 export default function EcosystemPage() {
@@ -47,7 +48,7 @@ export default function EcosystemPage() {
       } catch (err) {
         if (!mounted) return
         setError(err instanceof Error ? err.message : 'Failed to load ecosystem data')
-        console.error('Error loading ecosystem data:', err)
+        logger.error('Error loading ecosystem data:', err)
       } finally {
         if (mounted) {
           setIsLoading(false)

--- a/src/app/governance/[id]/page.tsx
+++ b/src/app/governance/[id]/page.tsx
@@ -7,6 +7,7 @@ import { UpgradeSummaryWidget } from '@/components/governance'
 import { LayoutWrapper } from '@/components/layout'
 import { fetchProposal } from '@/lib/api'
 import { formatProposalStatus, isUpgradeProposal } from '@/lib/governanceUtils'
+import { logger } from '@/lib/logger'
 import { Proposal } from '@/types'
 
 export default function ProposalDetailPage() {
@@ -28,7 +29,7 @@ export default function ProposalDetailPage() {
         const data = await fetchProposal(proposalId)
         setProposal(data.proposal)
       } catch (err) {
-        console.error('Error loading proposal:', err)
+        logger.error('Error loading proposal:', err)
         setError(err instanceof Error ? err.message : 'Failed to load proposal')
       } finally {
         setIsLoading(false)

--- a/src/app/governance/page.tsx
+++ b/src/app/governance/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { ProposalList } from '@/components/governance'
 import { LayoutWrapper } from '@/components/layout'
 import { fetchCurrentHeight, fetchProposals } from '@/lib/api'
+import { logger } from '@/lib/logger'
 import { ProposalsResponse } from '@/types'
 
 export default function GovernancePage() {
@@ -23,7 +24,7 @@ export default function GovernancePage() {
         setProposals(proposalsData)
         setCurrentHeight(height)
       } catch (err) {
-        console.error('Error loading governance data:', err)
+        logger.error('Error loading governance data:', err)
         setError(err instanceof Error ? err.message : 'Failed to load governance data')
       } finally {
         setIsLoading(false)

--- a/src/app/trust-registries/page.tsx
+++ b/src/app/trust-registries/page.tsx
@@ -5,6 +5,7 @@ import { LayoutWrapper } from '@/components/layout'
 import { ResultsSection, SearchForm } from '@/components/search'
 import { TrustRegistryTable } from '@/components/tables'
 import { fetchTrustRegistryList } from '@/lib/api'
+import { logger } from '@/lib/logger'
 import { TrustRegistry } from '@/types'
 
 export default function TrustRegistriesPage() {
@@ -25,7 +26,7 @@ export default function TrustRegistriesPage() {
         setError(null)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to load trust registries')
-        console.error('Error loading trust registries:', err)
+        logger.error('Error loading trust registries:', err)
       } finally {
         setIsLoading(false)
       }

--- a/src/components/governance/ProposalCard.tsx
+++ b/src/components/governance/ProposalCard.tsx
@@ -12,6 +12,7 @@ import {
   getExecutionStatusColor,
   isUpgradeProposal,
 } from '@/lib/governanceUtils'
+import { logger } from '@/lib/logger'
 import { Proposal, UpgradeExecutionInfo } from '@/types'
 
 interface ProposalCardProps {
@@ -53,7 +54,7 @@ export default function ProposalCard({
         const executionInfo = await determineUpgradeExecutionStatus(proposal, plan.height)
         setExecution(executionInfo)
       } catch (error) {
-        console.error('Error loading execution status:', error)
+        logger.error('Error loading execution status:', error)
       } finally {
         setIsLoadingExecution(false)
       }

--- a/src/components/governance/UpgradeSummaryWidget.tsx
+++ b/src/components/governance/UpgradeSummaryWidget.tsx
@@ -10,6 +10,7 @@ import {
   getExecutionStatusColor,
   parsePlanInfo,
 } from '@/lib/governanceUtils'
+import { logger } from '@/lib/logger'
 import { Proposal, UpgradeExecutionInfo, UpgradeProposalData, VotingSummary } from '@/types'
 
 interface UpgradeSummaryWidgetProps {
@@ -39,7 +40,7 @@ export default function UpgradeSummaryWidget({ proposal, className = '' }: Upgra
         const data = await buildUpgradeProposalData(proposal)
         setUpgradeData(data)
       } catch (err) {
-        console.error('Error loading upgrade data:', err)
+        logger.error('Error loading upgrade data:', err)
         setError(err instanceof Error ? err.message : 'Failed to load upgrade data')
       } finally {
         setIsLoading(false)

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -9,6 +9,7 @@ import {
   fetchSupply,
   formatInflationRate,
 } from '@/lib/api'
+import { logger } from '@/lib/logger'
 import Footer from './Footer'
 import MobileHeader from './MobileHeader'
 import Sidebar from './Sidebar'
@@ -71,7 +72,7 @@ export default function LayoutWrapper({ children, title, subtitle }: LayoutWrapp
           trustDepositSize,
         })
       } catch (error) {
-        console.error('Failed to load network info:', error)
+        logger.error('Failed to load network info:', error)
       }
     }
 

--- a/src/components/network/ForceGraph3DWrapper.tsx
+++ b/src/components/network/ForceGraph3DWrapper.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { logger } from '@/lib/logger'
 
 interface ForceGraph3DWrapperProps {
   [key: string]: any
@@ -22,7 +23,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
     // Wait for the library to load
     const initGraph = async () => {
       try {
-        console.log('Initializing 3D graph...')
+        logger.log('Initializing 3D graph...')
         setIsLoading(true)
         setError(null)
         initializedRef.current = false
@@ -41,7 +42,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
             break
           } catch (importError) {
             importAttempts++
-            console.warn(`Import attempt ${importAttempts} failed:`, importError)
+            logger.warn(`Import attempt ${importAttempts} failed:`, importError)
 
             if (importAttempts >= maxImportAttempts) {
               throw importError
@@ -69,7 +70,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
             }
           }
 
-          console.log('Creating ForceGraph3D instance...')
+          logger.log('Creating ForceGraph3D instance...')
           // 3d-force-graph default export is a FACTORY function, not a class
           // Prefer constructor per docs; pass rendererConfig to ensure alpha transparency
           try {
@@ -101,7 +102,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
                     try {
                       graphRef.current[key](props[key])
                     } catch (error) {
-                      console.warn(`Failed to apply prop ${key}:`, error)
+                      logger.warn(`Failed to apply prop ${key}:`, error)
                     }
                   }
                 })
@@ -116,14 +117,14 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
                   graphRef.current.refresh()
                 } catch {}
 
-                console.log('3D graph initialized successfully')
+                logger.log('3D graph initialized successfully')
                 initializedRef.current = true
                 setIsLoading(false)
               } catch (error) {
-                console.error('Error applying props to graph:', error)
+                logger.error('Error applying props to graph:', error)
                 // Don't show error if graph was initialized successfully, just log it
                 if (graphRef.current) {
-                  console.warn('Graph initialized but error applying props:', error)
+                  logger.warn('Graph initialized but error applying props:', error)
                 } else {
                   setError('Failed to initialize 3D visualization')
                 }
@@ -139,12 +140,12 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
             initializedRef.current = true
             setIsLoading(false)
           } catch (error) {
-            console.warn('Error updating existing graph:', error)
+            logger.warn('Error updating existing graph:', error)
             setIsLoading(false)
           }
         }
       } catch (error) {
-        console.error('Failed to initialize ForceGraph3D:', error)
+        logger.error('Failed to initialize ForceGraph3D:', error)
         // Only show error if this is a critical failure, not just a prop update error
         setError(`Failed to load 3D visualization: ${error instanceof Error ? error.message : String(error)}`)
         setIsLoading(false)
@@ -161,7 +162,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
         ? setTimeout(() => {
             // Only show timeout error if graph is still null and hasn't been initialized
             if (!initializedRef.current) {
-              console.error('3D graph initialization timeout')
+              logger.error('3D graph initialization timeout')
               setError('Initialization timeout - please try refreshing the page')
               setIsLoading(false)
             } else {
@@ -190,7 +191,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
       if (props.backgroundColor) graphRef.current.backgroundColor(props.backgroundColor)
       if (props.showNavInfo !== undefined) graphRef.current.showNavInfo(props.showNavInfo)
     } catch (error) {
-      console.warn('Failed to update graph props:', error)
+      logger.warn('Failed to update graph props:', error)
       // Don't show error if graph is working, just log the warning
     }
   }, [props.graphData, props.width, props.height, props.backgroundColor, props.showNavInfo])
@@ -206,7 +207,7 @@ const ForceGraph3DWrapper = forwardRef<any, ForceGraph3DWrapperProps>((props, re
         graphRef.current.width(props.width)
         graphRef.current.height(props.height)
       } catch (error) {
-        console.warn('Failed to resize graph:', error)
+        logger.warn('Failed to resize graph:', error)
       }
     }, 50) // Small delay to ensure DOM updates are complete
 

--- a/src/components/network/NetworkGraph3D.tsx
+++ b/src/components/network/NetworkGraph3D.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { convertUvnaToVna, fetchDIDList, fetchHeader, fetchTrustRegistryList } from '@/lib/api'
+import { logger } from '@/lib/logger'
 import type { DID, TrustRegistry } from '@/types'
 
 // Import the wrapper component
@@ -843,12 +844,12 @@ export default function NetworkGraph3D() {
           setPulseAnimation(false)
         }
       } catch (error) {
-        console.warn('Error fitting graph to view:', error)
+        logger.warn('Error fitting graph to view:', error)
         // Fallback: try to reset camera position
         try {
           graphRef.current.cameraPosition({ x: 0, y: 0, z: 200 }, { x: 0, y: 0, z: 0 }, 1000)
         } catch (fallbackError) {
-          console.warn('Fallback camera reset also failed:', fallbackError)
+          logger.warn('Fallback camera reset also failed:', fallbackError)
         }
       }
     }

--- a/src/lib/ecosystemDataFetcher.ts
+++ b/src/lib/ecosystemDataFetcher.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/lib/logger'
+
 import { EcosystemMetricsDataPoint } from '@/types'
 import { fetchEcosystemMetrics } from './api'
 import { calculateHistoricalHeights, getBlockAtHeight, getCurrentBlockHeight } from './historicalDataFetcher'
@@ -19,7 +21,7 @@ export async function fetchHistoricalEcosystemData(dataPoints: number = 30): Pro
         try {
           blockInfo = await getBlockAtHeight(height)
         } catch (err) {
-          console.warn(`Block fetch at height ${height} failed, skipping:`, err instanceof Error ? err.message : err)
+          logger.warn(`Block fetch at height ${height} failed, skipping:`, err instanceof Error ? err.message : err)
           return null
         }
 
@@ -27,7 +29,7 @@ export async function fetchHistoricalEcosystemData(dataPoints: number = 30): Pro
         try {
           metrics = await fetchEcosystemMetrics(height)
         } catch (error) {
-          console.warn(`Metrics fetch at height ${height} failed:`, error instanceof Error ? error.message : error)
+          logger.warn(`Metrics fetch at height ${height} failed:`, error instanceof Error ? error.message : error)
           return null
         }
 
@@ -64,7 +66,7 @@ export async function fetchHistoricalEcosystemData(dataPoints: number = 30): Pro
   }
 
   if (failureCount > 0) {
-    console.warn(`Ecosystem historical data: ${failureCount}/${heights.length} data points failed`)
+    logger.warn(`Ecosystem historical data: ${failureCount}/${heights.length} data points failed`)
   }
 
   return data.sort((a, b) => a.height - b.height)

--- a/src/lib/githubApi.ts
+++ b/src/lib/githubApi.ts
@@ -1,4 +1,5 @@
 import { env } from 'next-runtime-env'
+import { logger } from '@/lib/logger'
 import {
   AggregatedContributor,
   CommitActivity,
@@ -18,9 +19,9 @@ let hasWarnedAboutRateLimit = false
 function warnAboutRateLimit() {
   if (!hasWarnedAboutRateLimit) {
     if (getGitHubToken()) {
-      console.log('✅ GitHub API: Using authenticated requests (5,000 requests/hour limit)')
+      logger.log('✅ GitHub API: Using authenticated requests (5,000 requests/hour limit)')
     } else {
-      console.warn(
+      logger.warn(
         '⚠️ GitHub API: Using unauthenticated requests (60 requests/hour limit). ' +
           'Add NEXT_PUBLIC_GITHUB_TOKEN to .env.local for higher limits (5,000 requests/hour).'
       )
@@ -72,7 +73,7 @@ export async function fetchOrganizationRepos(org: string): Promise<GitHubReposit
         const resetDate = rateLimitReset ? new Date(parseInt(rateLimitReset) * 1000) : null
         const resetTimeStr = resetDate ? resetDate.toLocaleTimeString() : 'unknown'
 
-        console.error('GitHub API 403 Error Details:', {
+        logger.error('GitHub API 403 Error Details:', {
           rateLimitRemaining,
           rateLimitReset,
           resetTime: resetTimeStr,
@@ -110,7 +111,7 @@ export async function fetchOrganizationRepos(org: string): Promise<GitHubReposit
     // Filter out private repos and forks (external repositories)
     return repos.filter((repo) => !repo.name.includes('private') && !repo.fork)
   } catch (error) {
-    console.error('Error fetching organization repos:', error)
+    logger.error('Error fetching organization repos:', error)
     throw error
   }
 }
@@ -135,7 +136,7 @@ export async function fetchRepositoryCommits(owner: string, repo: string, since?
 
     return await response.json()
   } catch (error) {
-    console.error(`Error fetching commits for ${owner}/${repo}:`, error)
+    logger.error(`Error fetching commits for ${owner}/${repo}:`, error)
     return []
   }
 }
@@ -152,20 +153,20 @@ export async function fetchRepositoryContributors(owner: string, repo: string): 
     if (!response.ok) {
       if (response.status === 409 || response.status === 404) {
         // Repository is empty or not found
-        console.log(`No contributors found for ${owner}/${repo} (${response.status})`)
+        logger.log(`No contributors found for ${owner}/${repo} (${response.status})`)
         return []
       }
       if (response.status === 403) {
-        console.warn(`Rate limit or access denied for ${owner}/${repo}`)
+        logger.warn(`Rate limit or access denied for ${owner}/${repo}`)
         return []
       }
-      console.warn(`Failed to fetch contributors for ${owner}/${repo}: ${response.statusText}`)
+      logger.warn(`Failed to fetch contributors for ${owner}/${repo}: ${response.statusText}`)
       return []
     }
 
     return await response.json()
   } catch (error) {
-    console.error(`Error fetching contributors for ${owner}/${repo}:`, error)
+    logger.error(`Error fetching contributors for ${owner}/${repo}:`, error)
     return []
   }
 }
@@ -187,13 +188,13 @@ export async function fetchCommitActivity(owner: string, repo: string): Promise<
 
     // GitHub returns 202 if stats are being computed
     if (response.status === 202) {
-      console.log(`Stats are being computed for ${owner}/${repo}`)
+      logger.log(`Stats are being computed for ${owner}/${repo}`)
       return []
     }
 
     return data || []
   } catch (error) {
-    console.error(`Error fetching commit activity for ${owner}/${repo}:`, error)
+    logger.error(`Error fetching commit activity for ${owner}/${repo}:`, error)
     return []
   }
 }
@@ -335,7 +336,7 @@ export async function fetchRepositoryStats(owner: string, repo: string): Promise
 
     // Fallback: If GitHub stats API doesn't return data, generate from commits
     if (!commitActivity || commitActivity.length === 0) {
-      console.log(`Generating commit activity from commits for ${owner}/${repo}`)
+      logger.log(`Generating commit activity from commits for ${owner}/${repo}`)
       commitActivity = generateCommitActivityFromCommits(commits)
     }
 
@@ -354,7 +355,7 @@ export async function fetchRepositoryStats(owner: string, repo: string): Promise
       commitActivity,
     }
   } catch (error) {
-    console.error(`Error fetching repository stats for ${owner}/${repo}:`, error)
+    logger.error(`Error fetching repository stats for ${owner}/${repo}:`, error)
     return null
   }
 }

--- a/src/lib/governanceUtils.ts
+++ b/src/lib/governanceUtils.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/lib/logger'
+
 /**
  * Governance Utilities
  *
@@ -306,7 +308,7 @@ export async function determineUpgradeExecutionStatus(
   try {
     currentHeight = await fetchCurrentHeight()
   } catch (error) {
-    console.error('Error fetching current height:', error)
+    logger.error('Error fetching current height:', error)
     // Rule 3: Current height unavailable
     return {
       status: 'not_executed',
@@ -352,7 +354,7 @@ export async function determineUpgradeExecutionStatus(
         }
       }
     } catch (error) {
-      console.error(`Error fetching block at height ${planHeight}:`, error)
+      logger.error(`Error fetching block at height ${planHeight}:`, error)
       return {
         status: 'unknown',
         message: `Unknown (block not available)`,
@@ -394,7 +396,7 @@ export async function buildVotingSummary(proposal: Proposal): Promise<VotingSumm
     const stakingPool = await fetchStakingPool()
     bondedTokens = stakingPool.pool?.bonded_tokens || '0'
   } catch (error) {
-    console.error('Error fetching staking pool:', error)
+    logger.error('Error fetching staking pool:', error)
   }
 
   const turnoutPercent = calculateTurnoutPercent(totalVotingPower, bondedTokens)

--- a/src/lib/historicalDataFetcher.ts
+++ b/src/lib/historicalDataFetcher.ts
@@ -1,3 +1,5 @@
+import { logger } from '@/lib/logger'
+
 /**
  * Historical Data Fetcher
  * Fetches historical blockchain data by querying state at different block heights.
@@ -25,7 +27,7 @@ export async function getCurrentBlockHeight(): Promise<number> {
     const data = await response.json()
     return parseInt(data.result?.block?.header?.height || '0')
   } catch (error) {
-    console.error('Error fetching current block height:', error)
+    logger.error('Error fetching current block height:', error)
     throw error
   }
 }
@@ -42,7 +44,7 @@ export async function getBlockAtHeight(height: number): Promise<BlockInfo> {
       timestamp: data.result?.block?.header?.time || new Date().toISOString(),
     }
   } catch (error) {
-    console.error(`Error fetching block at height ${height}:`, error)
+    logger.error(`Error fetching block at height ${height}:`, error)
     throw error
   }
 }
@@ -56,7 +58,7 @@ export async function getSupplyAtHeight(height: number) {
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
-    console.error(`Error fetching supply at height ${height}:`, error)
+    logger.error(`Error fetching supply at height ${height}:`, error)
     return null
   }
 }
@@ -70,7 +72,7 @@ export async function getStakingPoolAtHeight(height: number) {
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
-    console.error(`Error fetching staking pool at height ${height}:`, error)
+    logger.error(`Error fetching staking pool at height ${height}:`, error)
     return null
   }
 }
@@ -84,7 +86,7 @@ export async function getInflationAtHeight(height: number) {
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
-    console.error(`Error fetching inflation at height ${height}:`, error)
+    logger.error(`Error fetching inflation at height ${height}:`, error)
     return null
   }
 }
@@ -98,7 +100,7 @@ export async function getValidatorsAtHeight(height: number) {
     if (!response.ok) throw new Error(`HTTP ${response.status}`)
     return await response.json()
   } catch (error) {
-    console.error(`Error fetching validators at height ${height}:`, error)
+    logger.error(`Error fetching validators at height ${height}:`, error)
     return null
   }
 }
@@ -188,7 +190,7 @@ export async function fetchHistoricalSupplyData(dataPoints: number = 30): Promis
 
     return data.sort((a, b) => a.height - b.height)
   } catch (error) {
-    console.error('Error fetching historical supply data:', error)
+    logger.error('Error fetching historical supply data:', error)
     throw error
   }
 }
@@ -246,7 +248,7 @@ export async function fetchHistoricalInflationData(dataPoints: number = 30): Pro
 
     return data.sort((a, b) => a.height - b.height)
   } catch (error) {
-    console.error('Error fetching historical inflation data:', error)
+    logger.error('Error fetching historical inflation data:', error)
     throw error
   }
 }
@@ -325,7 +327,7 @@ export async function fetchHistoricalNetworkActivity(dataPoints: number = 30): P
 
     return data.sort((a, b) => a.height - b.height)
   } catch (error) {
-    console.error('Error fetching historical network activity:', error)
+    logger.error('Error fetching historical network activity:', error)
     throw error
   }
 }
@@ -357,7 +359,7 @@ export async function fetchCurrentValidatorDistribution(): Promise<ValidatorData
       .sort((a: any, b: any) => b.votingPower - a.votingPower)
       .slice(0, 10)
   } catch (error) {
-    console.error('Error fetching validator distribution:', error)
+    logger.error('Error fetching validator distribution:', error)
     throw error
   }
 }
@@ -404,7 +406,7 @@ export async function fetchCurrentStakingDistribution(): Promise<StakingDataPoin
       },
     ]
   } catch (error) {
-    console.error('Error fetching staking distribution:', error)
+    logger.error('Error fetching staking distribution:', error)
     throw error
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,21 @@
+/**
+ * biome-ignore-all lint/suspicious/noConsole: this module is the single
+ * permitted console-call site; all app code routes through `logger`.
+ */
+
+type Level = 'error' | 'warn' | 'info' | 'debug' | 'log'
+
+const isProduction = process.env.NODE_ENV === 'production'
+
+function emit(level: Level, ...args: unknown[]): void {
+  if (level === 'debug' && isProduction) return
+  console[level](...args)
+}
+
+export const logger = {
+  error: (...args: unknown[]) => emit('error', ...args),
+  warn: (...args: unknown[]) => emit('warn', ...args),
+  info: (...args: unknown[]) => emit('info', ...args),
+  debug: (...args: unknown[]) => emit('debug', ...args),
+  log: (...args: unknown[]) => emit('log', ...args),
+}


### PR DESCRIPTION
Introduces a small `src/lib/logger.ts` shim and replaces every `console.*` call site in app code (~63 calls across 18 files) with the equivalent `logger.*` call.

Related to #35.