### PR TITLE
ci: bump docker actions off deprecated node runtimes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,17 +53,17 @@ jobs:
           fi
 
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build & push dev tags
         if: env.RELEASE_TYPE == 'dev'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
@@ -80,7 +80,7 @@ jobs:
 
       - name: Build & push stable release tags
         if: env.RELEASE_TYPE == 'stable'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Closes #42

Follow-up to #41. That one bumped `checkout` and `setup-helm` but left the docker actions in `cd.yml` on old node, `docker/login-action@v2` was still on node16 and the `build-push-action@v5` / `setup-buildx-action@v3` steps on node20. This pins all three to commit SHAs and moves them to the current node24 releases: `login-action` v4.4.0, `build-push-action` v7.3.0 (both build steps), `setup-buildx-action` v4.2.0.

These are 1-2 major jumps but the usage here is a plain username/password login and a standard build/push, nothing that changed across those versions. Only thing to watch is this workflow only runs on release, so it won't be exercised until the next one, worth a glance at that run.